### PR TITLE
Chore: Widen `.svg` ignore radius

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-**/diagrams/**/.svg
 .ignore
 
 ~$*.xlsx
+.svg


### PR DESCRIPTION
- Allow ignoring any `.svg` folder anywhere in the repo.
